### PR TITLE
SPECAM-87 -- Specify the OPT 2 ADL syntax for C_ARCHETYPE_ROOT with c…

### DIFF
--- a/docs/ADL2/master10-templates.adoc
+++ b/docs/ADL2/master10-templates.adoc
@@ -259,9 +259,9 @@ definition
 		}
 		context existence matches {0}
 		content matches {
-			SECTION[id0.1, openEHR-EHR-SECTION.t_patient_event_info_ds_sf.v1.0.0] occurrences matches {1} matches {	-- Event start
+			use_archetype SECTION[id0.1, openEHR-EHR-SECTION.t_patient_event_info_ds_sf.v1.0.0] occurrences matches {1} matches {	-- Event start
 				items matches {
-					ADMIN_ENTRY[id0.1, openEHR-EHR-ADMIN_ENTRY.t_patient_event_info_ds_sf-1.v1.0.0] occurrences matches {1} matches {
+					use_archetype ADMIN_ENTRY[id0.1, openEHR-EHR-ADMIN_ENTRY.t_patient_event_info_ds_sf-1.v1.0.0] occurrences matches {1} matches {
 						other_participations existence matches {0}
                     }
                     --- etc ---


### PR DESCRIPTION
…hild nodes

This changes the syntax in the OPT example in the ADL 2 specification to include use_archetype for archetype roots. This is linked to a change in the grammar, with the pull request https://github.com/openEHR/adl-antlr/pull/35