### PR TITLE
Update link to base instead of support master07.06-adl_specialise.adoc

### DIFF
--- a/docs/ADL2/master07.06-adl_specialise.adoc
+++ b/docs/ADL2/master07.06-adl_specialise.adoc
@@ -10,11 +10,11 @@ specialise
     openEHR-EHR-OBSERVATION.haematology.v1
 --------
 
-Here the identifier of the new archetype is derived from that of the parent by adding a new section to its domain concept section. See the `ARCHETYPE_ID` definition in the identification package in the {openehr_rm_support}[openEHR Support IM specification^].
+Here the identifier of the new archetype is derived from that of the parent by adding a new section to its domain concept section. See the `ARCHETYPE_ID` definition in the identification package in the {openehr_base}[openEHR BASE specification^].
 
 Note that both the US and British English versions of the word "specialise" are valid in ADL.
 
 The following syntax validity rule applies in the specialisation section:
 
 [.rule]
-SASID: archetype specialisation parent identifier validity. for specialised artefacts, the identifier of the specialisation parent must conform to the ARCHETYPE_ID identifier syntax defined in the {openehr_rm_support}[openEHR Support IM specification^].
+SASID: archetype specialisation parent identifier validity. for specialised artefacts, the identifier of the specialisation parent must conform to the ARCHETYPE_ID identifier syntax defined in the {openehr_base}[openEHR BASE specification^].


### PR DESCRIPTION
The archetype_id is now (AM2) in 'BASE' not 'support'.

Draft: please check the link, the syntax was unclear to me. 