### PR TITLE
Replace miniHRID  master07-referencing.adoc

### DIFF
--- a/docs/Identification/master07-referencing.adoc
+++ b/docs/Identification/master07-referencing.adoc
@@ -38,7 +38,7 @@ This section describes the scenarios and representation required for identifier-
 
 === Archetype External References (ADL/AOM 2)
 
-In ADL 2, a direct archetype-archetype reference, known as an 'external reference' can be defined, which uses the archetype miniHRID, as shown in the following example.
+In ADL 2, a direct archetype-archetype reference, known as an 'external reference' can be defined, which uses the interface HRID reference, as shown in the following example.
 
 [tabs,sync-group-id=adl-example]
 ====


### PR DESCRIPTION
Mini HRID is undefined. Based on the previous section I assume the original meaning is compatible with ‘interface HRID’. 

Draft: 1: Though it’s not clear to me whether that’s compatible with the next sentence that dropping the namespace means it’s the same namespace as the current archetype.

2: It could also refer to the archetype_hrid from aom2. But that already states it’s only the major version number. So the mini could be removed. But since this is clearly a reference (not a class attribute) I think aom2 is not very relevant here.