### PR TITLE
Change at code numbering in master07-referencing.adoc

### DIFF
--- a/docs/Identification/master07-referencing.adoc
+++ b/docs/Identification/master07-referencing.adoc
@@ -234,10 +234,10 @@ The semantics of referencing in queries differ from those of the archetype-to-ar
 
 [source, cadl]
 --------
-    [openEHR-EHR-OBSERVATION.pulse.v1]/data/events[at0006]/data/items[at0004]/value/value
+    [openEHR-EHR-OBSERVATION.pulse.v1]/data/events[at0005]/data/items[at0003]/value/value
 --------
 
-For this to be valid, the path `/data/events[at0006]/data/items[at0004]/value/value` must exist within the earliest v1.x release of the archetype openEHR-EHR-OBSERVATION.pulse.v1, i.e. v1.0.0. If this path happened to have been added in a more recent minor release, the archetype reference would need to include the first minor version containing that path.
+For this to be valid, the path `/data/events[at0005]/data/items[at0003]/value/value` must exist within the earliest v1.x release of the archetype openEHR-EHR-OBSERVATION.pulse.v1, i.e. v1.0.0. If this path happened to have been added in a more recent minor release, the archetype reference would need to include the first minor version containing that path.
 
 Once an AQL query processor can work with a valid path, it will match the following data:
 


### PR DESCRIPTION
This probably went wrong due to renumbering of at codes in the #16 pr. 

Ideally there would also be an example for ID coded archetypes in a tab. But I wasn’t sure of the syntax. 