### PR TITLE
Remove implied second location of grammars  masterAppB-syntax_spec.adoc

### DIFF
--- a/docs/ADL2/masterAppB-syntax_spec.adoc
+++ b/docs/ADL2/masterAppB-syntax_spec.adoc
@@ -1,7 +1,7 @@
 [appendix]
 = Syntax Specification
 
-The normative specification of the ADL2 syntax is expressed in Antlr4 as a series of component grammars, shown below. This has been tested with the Antlr 4.9 implementation available from http://www.antlr.org[Antlr.org^]. The source files are available in two locations on Github - {openehr_adl_antlr}/tree/master/src/main/antlr/adl[adl-antlr repository^]. The ODIN grammar used in parts of an ADL archetype is not shown below, it can be found in the {openehr_odin}[openEHR ODIN specification^].
+The normative specification of the ADL2 syntax is expressed in Antlr4 as a series of component grammars, shown below. This has been tested with the Antlr 4.9 implementation available from http://www.antlr.org[Antlr.org^]. The source files are available on GitHub - {openehr_adl_antlr}/tree/master/src/main/antlr/adl[adl-antlr repository^]. The ODIN grammar used in parts of an ADL archetype is not shown below, it can be found in the {openehr_odin}[openEHR ODIN specification^].
 
 == ADL Outer Syntax
 


### PR DESCRIPTION
I see only one link and believe there’s now only one grammar for ADL2. There’s no longer an adl2 grammar under AM on GitHub. Archie (now) derives its grammar from the openEHR antlr grammar. 