### PR TITLE
allow '-beta' version suffix in archetype identification.adoc

### DIFF
--- a/docs/Identification/master04-versioning.adoc
+++ b/docs/Identification/master04-versioning.adoc
@@ -41,7 +41,7 @@ Lexically, the version identifier is defined as follows:
     minor_version     =   { V_NUMBER } ;
     patch_version     =   { V_NUMBER } ;
     extension         =   version_modifier '.' issue_number ;
-    version_modifier  =   '-rc' | '-alpha' ;
+    version_modifier  =   '-rc' | '-alpha' | '-beta' ;
     issue_number      =   V_NUMBER ;
     V_NUMBER          =   { V_DIGIT }+ ;
     V_DIGIT           =   '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' ;


### PR DESCRIPTION
Is this the right place to edit? Or is this taken from (some) antlr grammar?

edit: for now let's just improve this. and fix grammars separately.