### PR TITLE
SPECAM-88 - Template overlay naming spec and examples are inconsistent

### DIFF
--- a/docs/AOM2/master10-templates.adoc
+++ b/docs/AOM2/master10-templates.adoc
@@ -82,9 +82,9 @@ The following are examples.
 --------
 uk.nhs.clinical::openEHR-EHR-COMPOSITION.t_encounter_report.v1.0.0  -- root template
 
-uk.nhs.clinical::openEHR-EHR-EVALUATION.t_encounter_report-problem_description-1.v1.0.0   -- overlay
-uk.nhs.clinical::openEHR-EHR-EVALUATION.t_encounter_report-medications-2.v1.0.0           -- overlay
-uk.nhs.clinical::openEHR-EHR-EVALUATION.t_encounter_report-care_plan-3.v1.0.0             -- overlay
+uk.nhs.clinical::openEHR-EHR-EVALUATION.t_encounter_report-problem_description_1.v1.0.0   -- overlay
+uk.nhs.clinical::openEHR-EHR-EVALUATION.t_encounter_report-medications_2.v1.0.0           -- overlay
+uk.nhs.clinical::openEHR-EHR-EVALUATION.t_encounter_report-care_plan_3.v1.0.0             -- overlay
 --------
 
 This approach defines a short concept identifier which obeys the formal rule that concept identifiers   must be unique within a namespace and RM type, is human-readable, and most importantly, is tool-generatable.


### PR DESCRIPTION
Update examples from:
uk.nhs.clinical::openEHR-EHR-EVALUATION.t_encounter_report-problem_description-1.v1.0.0
to
uk.nhs.clinical::openEHR-EHR-EVALUATION.t_encounter_report-problem_description_1.v1.0.0